### PR TITLE
Use secure URI in Vcs-Git control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bats (0.4.0-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs-Git control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Wed, 12 Sep 2018 03:36:41 +0100
+
 bats (0.4.0-1.1) unstable; urgency=medium
 
   * Non-maintainer upload.

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Yaroslav Halchenko <debian@onerussian.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.6
 Homepage: https://github.com/sstephenson/bats
-Vcs-Git: git://github.com/neurodebian/bats -b debian
+Vcs-Git: https://github.com/neurodebian/bats -b debian
 Vcs-Browser: https://github.com/neurodebian/bats
 
 Package: bats


### PR DESCRIPTION
Use secure URI in Vcs-Git control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
